### PR TITLE
Add HA_VERSION to _compiled_version in compiler.spec

### DIFF
--- a/src/compiler.spec
+++ b/src/compiler.spec
@@ -22,6 +22,8 @@ elif utils.LINUX:
 else:
     suffix = ''
 
+HA_VERSION = utils.get_git_version(hammeraddons)
+
 # Unneeded packages that cx_freeze detects:
 EXCLUDES = [
     'bz2',  # We aren't using this compression format (shutil, zipfile etc handle ImportError)..
@@ -120,7 +122,10 @@ print('DATA:', data_files)
 
 # Write this to the temp folder, so it's picked up and included.
 # Don't write it out though if it's the same, so PyInstaller doesn't reparse.
-version_val = 'BEE_VERSION=' + repr(utils.get_git_version(SPECPATH))
+version_val = f'''\
+BEE_VERSION={utils.get_git_version(SPECPATH)!r}
+HA_VERSION={HA_VERSION!r}
+'''
 print(version_val)
 version_filename = os.path.join(workpath, '_compiled_version.py')
 


### PR DESCRIPTION
Trying to compile a map would raise an exception about HA_VERSION being undefined. This just copies the relevant code over from BEE2.spec.