### PR TITLE
README.md Compilation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ As of version 4.37 we have stopped supporting BEE2.4 on Mac. See [this wiki arti
 * First, grab the repo and then clone the HammerAddons submodule:
 
 	    git clone --recurse-submodules https://github.com/BEEmod/BEE2.4.git
-      cd BEE2.4
-	    git submodules update --init
+	    cd BEE2.4
+	    git submodule update --init
 
 * Run `python -m pip install -r requirements.txt` to install the required packages. On Linux, 
 Pillow, TK and IDLE might need to be installed via the system package manager:
@@ -57,9 +57,9 @@ Pillow, TK and IDLE might need to be installed via the system package manager:
 	* In the `BEE2.4` folder, add `lib-32` and/or `lib-64/` folders.
 	* Download the [32-bit](https://github.com/sudo-nautilus/FFmpeg-Builds-Win32/releases) or [64-bit](https://github.com/BtbN/FFmpeg-Builds/releases) builds (`winXX-lgpl-shared`), then copy the contents of the `bin` folder into the appropriate `lib-XX` folder mentioned.
 
-* Finally, switch to the BEE2.4 repo and build the compiler, then the application:
+* Finally, switch to the BEE2.4 repo and build the compiler, then the application (You should be in the BEE2.4 folder already):
 
-	    cd BEE2.4/src/
+	    cd src/
 	    pyinstaller --distpath ../dist/64bit/ --workpath ../build_tmp compiler.spec
 	    pyinstaller --distpath ../dist/64bit/ --workpath ../build_tmp BEE2.spec
 	
@@ -68,3 +68,5 @@ To generate the packages zips, either manually zip the contents of each folder o
 use the `compile_packages` script in BEE2-items. 
 This does the same thing, but additionally removes some unnessary content 
 to decrease file sizes - comments, blank lines, hidden visgroups.
+
+* For Linux Compilation check out this wiki entry [Building from Source](https://github.com/BEEmod/BEE2-items/wiki/Building-from-source) 


### PR DESCRIPTION
Fixes 'git submodules update --init' to 'git submodule update --init' since the 'git submodules' command is presumably from a older version 
Adds Linux compilation wiki entry
Changes 'cd BEE2/src/' to 'cd src/' since user is in that folder already