### PR TITLE
Add On/Off functionality for coop

### DIFF
--- a/src/postcomp/coop_responses.py
+++ b/src/postcomp/coop_responses.py
@@ -7,7 +7,7 @@ LOGGER = srctools.logger.get_logger(__name__)
 
 @trans('BEE2: Coop Responses')
 def generate_coop_responses(ctx: Context) -> None:
-    """If the entities are present, add the coop response script."""
+    """Add the coop response script."""
     responses: dict[str, list[str]] = {}
     for response in ctx.vmf.by_class['bee2_coop_response']:
         responses[response['type'].casefold()] = [
@@ -15,10 +15,17 @@ def generate_coop_responses(ctx: Context) -> None:
             if key.startswith('choreo')
         ]
         response.remove()
-        
-    if not responses:
-        return
-   
+
+    # Always add even if no responses are present and we're in MP - this is also
+    # used for general coop-death callbacks.
+    if ctx.vmf.spawn['BEE2_game_mode'].casefold() == 'sp':
+        if responses:
+            LOGGER.warning(
+                "bee2_coop_response entities present, but we're in singleplayer. "
+                "Still adding script.")
+        else:  # Singleplayer and no responses, skip.
+            return
+
     script = ["BEE2_RESPONSES <- {"]
     for response_type, lines in sorted(responses.items()):
         script.append(f'\t{response_type} = [')
@@ -36,5 +43,5 @@ def generate_coop_responses(ctx: Context) -> None:
         split_script.append('bee2/coop_responses.nut')
         ent['vscripts'] = ' '.join(split_script)
 
-    if ent is None:
+    if ent is None and responses:
         LOGGER.warning('Response scripts present, but @glados is not!')

--- a/src/vbsp.py
+++ b/src/vbsp.py
@@ -512,6 +512,19 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
         else:
             # In coop we have not need to actually spawn portalguns. 
             pgun_script['classname'] = 'logic_script'
+            # Make sure @portalman knows when players spawn
+            vmf.create_ent(
+                classname='comp_relay',
+                targetname='@on_player_spawn_2',
+                origin=ent_pos,
+                OnTrigger="@portalgunCallScriptFunctionon_oran_spawn0-1"
+            )
+            vmf.create_ent(
+                classname='comp_relay',
+                targetname='@on_player_spawn_3',
+                origin=ent_pos,
+                OnTrigger="@portalgunCallScriptFunctionon_blue_spawn0-1"
+            )
 
             # For Absolute Fizzler or otherwise, this fizzles portals on a
             # player remotely.

--- a/src/vbsp.py
+++ b/src/vbsp.py
@@ -508,8 +508,9 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
             )
             pgun_script['Template01'] = '__pgun_template'
             pgun_script['spawnflags'] = 2
+            
         else:
-            # In coop we have not need to actually spawn portalguns.
+            # In coop we have not need to actually spawn portalguns. 
             pgun_script['classname'] = 'logic_script'
 
             # For Absolute Fizzler or otherwise, this fizzles portals on a
@@ -527,6 +528,7 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
                 ent_pos - 4, ent_pos + 4,
                 mat=consts.Tools.TRIGGER,
             ).solid)
+
 
         # For removing portalguns from players.
         trig_stripper = vmf.create_ent(
@@ -598,19 +600,19 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
                 '_mark_held_cube()',
             ))
 
-        if info.is_sp:
-            logic_auto.add_out(Output(
-                'OnMapSpawn',
-                '@portalgun',
-                'RunScriptCode',
-                'init({}, {}, {})'.format(
-                    'true' if blue_portal else 'false',
-                    'true' if oran_portal else 'false',
-                    'true' if has_btn_onoff else 'false',
-                ),
-                delay=0.1,
-                only_once=True,
-            ))
+        #Init @portalgun
+        logic_auto.add_out(Output(
+            'OnMapSpawn',
+            '@portalgun',
+            'RunScriptCode',
+            'init({}, {}, {})'.format(
+                'true' if blue_portal else 'false',
+                'true' if oran_portal else 'false',
+                'true' if has_btn_onoff else 'false',
+            ),
+            delay=0.1,
+            only_once=True,
+        ))
 
         # Shuts down various parts when you've reached the exit.
         import precomp.conditions.instances

--- a/src/vbsp.py
+++ b/src/vbsp.py
@@ -527,23 +527,6 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
         else:
             # In coop we have not need to actually spawn portalguns. 
             pgun_script['classname'] = 'logic_script'
-            # Make sure @portalman knows when players spawn
-            trig_spawn_oran = vmf.create_ent(
-                classname='trigger_playerteam',
-                targetname='@on_player_spawn_2',
-                origin=ent_pos,
-                target_team=2,
-                OnStartTouch="@portalgunCallScriptFunctionon_oran_spawn0-1"
-            )
-            trig_spawn_blue = vmf.create_ent(
-                classname='trigger_playerteam',
-                targetname='@on_player_spawn_3',
-                origin=ent_pos,
-                target_team=3,
-                OnStartTouch="@portalgunCallScriptFunctionon_blue_spawn0-1"
-            )
-            trig_spawn_oran.solids = [whole_map.copy()]
-            trig_spawn_blue.solids = [whole_map.copy()]
 
             # For Absolute Fizzler or otherwise, this fizzles portals on a
             # player remotely.

--- a/src/vbsp.py
+++ b/src/vbsp.py
@@ -515,8 +515,9 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
             )
             pgun_script['Template01'] = '__pgun_template'
             pgun_script['spawnflags'] = 2
+            
         else:
-            # In coop we have not need to actually spawn portalguns.
+            # In coop we have not need to actually spawn portalguns. 
             pgun_script['classname'] = 'logic_script'
 
             # For Absolute Fizzler or otherwise, this fizzles portals on a
@@ -534,6 +535,7 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
                 ent_pos - 4, ent_pos + 4,
                 mat=consts.Tools.TRIGGER,
             ).solid)
+
 
         # For removing portalguns from players.
         trig_stripper = vmf.create_ent(
@@ -605,19 +607,19 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
                 '_mark_held_cube()',
             ))
 
-        if info.is_sp:
-            logic_auto.add_out(Output(
-                'OnMapSpawn',
-                '@portalgun',
-                'RunScriptCode',
-                'init({}, {}, {})'.format(
-                    'true' if blue_portal else 'false',
-                    'true' if oran_portal else 'false',
-                    'true' if has_btn_onoff else 'false',
-                ),
-                delay=0.1,
-                only_once=True,
-            ))
+        #Init @portalgun
+        logic_auto.add_out(Output(
+            'OnMapSpawn',
+            '@portalgun',
+            'RunScriptCode',
+            'init({}, {}, {})'.format(
+                'true' if blue_portal else 'false',
+                'true' if oran_portal else 'false',
+                'true' if has_btn_onoff else 'false',
+            ),
+            delay=0.1,
+            only_once=True,
+        ))
 
         # Shuts down various parts when you've reached the exit.
         import precomp.conditions.instances

--- a/src/vbsp.py
+++ b/src/vbsp.py
@@ -519,6 +519,19 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
         else:
             # In coop we have not need to actually spawn portalguns. 
             pgun_script['classname'] = 'logic_script'
+            # Make sure @portalman knows when players spawn
+            vmf.create_ent(
+                classname='comp_relay',
+                targetname='@on_player_spawn_2',
+                origin=ent_pos,
+                OnTrigger="@portalgunCallScriptFunctionon_oran_spawn0-1"
+            )
+            vmf.create_ent(
+                classname='comp_relay',
+                targetname='@on_player_spawn_3',
+                origin=ent_pos,
+                OnTrigger="@portalgunCallScriptFunctionon_blue_spawn0-1"
+            )
 
             # For Absolute Fizzler or otherwise, this fizzles portals on a
             # player remotely.

--- a/src/vbsp.py
+++ b/src/vbsp.py
@@ -503,7 +503,15 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
             vscripts='bee2/portal_man.nut',
             origin=ent_pos,
         )
-
+        
+        # Max map size is +-16384, for some reason we can't have a brush bigger than
+        # that in any dimension?
+        whole_map = vmf.make_prism(
+            Vec(-8192, -8192, -8192),
+            Vec(8192, 8192, 8192),
+            mat=consts.Tools.TRIGGER,
+        ).solid
+        
         if info.is_sp:
             vmf.create_ent(
                 classname='weapon_portalgun',
@@ -520,18 +528,22 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
             # In coop we have not need to actually spawn portalguns. 
             pgun_script['classname'] = 'logic_script'
             # Make sure @portalman knows when players spawn
-            vmf.create_ent(
-                classname='comp_relay',
+            trig_spawn_oran = vmf.create_ent(
+                classname='trigger_playerteam',
                 targetname='@on_player_spawn_2',
                 origin=ent_pos,
-                OnTrigger="@portalgunCallScriptFunctionon_oran_spawn0-1"
+                target_team=2,
+                OnStartTouch="@portalgunCallScriptFunctionon_oran_spawn0-1"
             )
-            vmf.create_ent(
-                classname='comp_relay',
+            trig_spawn_blue = vmf.create_ent(
+                classname='trigger_playerteam',
                 targetname='@on_player_spawn_3',
                 origin=ent_pos,
-                OnTrigger="@portalgunCallScriptFunctionon_blue_spawn0-1"
+                target_team=3,
+                OnStartTouch="@portalgunCallScriptFunctionon_blue_spawn0-1"
             )
+            trig_spawn_oran.solids = [whole_map.copy()]
+            trig_spawn_blue.solids = [whole_map.copy()]
 
             # For Absolute Fizzler or otherwise, this fizzles portals on a
             # player remotely.
@@ -559,13 +571,6 @@ def set_player_portalgun(vmf: VMF, info: corridor.Info) -> None:
             spawnflags=1,  # Players
             KillWeapons=1,
         )
-        # Max map size is +-16384, for some reason we can't have a brush bigger than
-        # that in any dimension?
-        whole_map = vmf.make_prism(
-            Vec(-8192, -8192, -8192),
-            Vec(8192, 8192, 8192),
-            mat=consts.Tools.TRIGGER,
-        ).solid
 
         trig_stripper.solids = [whole_map]
 


### PR DESCRIPTION
When we have portal_man:
- `logic_auto` calls `init` on `@portalgun` regardless of whether or not in singleplayer
- Moved `whole_map` definition (was going to be used for alternate implementation)