### PR TITLE
Updated Behavior Checks For VBSP and VRAD

### DIFF
--- a/src/compiler_launch.py
+++ b/src/compiler_launch.py
@@ -47,8 +47,7 @@ elif app_name == 'error_server':
     import error_server
     func = error_server.main
 else:
-    # Something broke with the earlier checks if the program got here.
-    sys.exit(f'Unable to set application behavior for "{app_name}"!')
+    raise AssertionError(app_name)
 
 from trio_debug import Tracer
 tracer = Tracer() if utils.CODE_DEV_MODE else None

--- a/src/compiler_launch.py
+++ b/src/compiler_launch.py
@@ -16,13 +16,15 @@ else:
     # Sourcecode-launch - check first sys arg.
     app_name = sys.argv.pop(1).casefold()
 
-app_name = app_name.removesuffix('_osx').removesuffix('_linux').removesuffix('.exe')
-
 if 'original' in app_name:
-    sys.exit('Original compilers replaced, verify game files in Steam!')
+    sys.exit('Original compilers were replaced! Please verify game files in Steam!')
 
-if app_name not in ('vbsp', 'vrad'):
-    sys.exit(f'Unknown application name "{app_name}"!')
+if not app_name.startswith(('vbsp', 'vrad')):
+    sys.exit(f'Invalid application name: "{app_name}"! Filename must start with "vbsp" or "vrad" to set application behavior.')
+
+# Remove the latter half of the app_name after the initial valid application behavior checks have been done.
+app_name = app_name.split(".")[0]
+app_name = app_name.split("_")[0]
 
 if app_name == 'vrad' and '--errorserver' in sys.argv:
     app_name = 'error_server'
@@ -38,14 +40,15 @@ LOGGER.info('Running "{}", version {}:', app_name, utils.BEE_VERSION)
 if app_name == 'vbsp':
     import vbsp
     func = vbsp.main
-elif app_name == 'error_server':
-    import error_server
-    func = error_server.main
 elif app_name == 'vrad':
     import vrad
     func = vrad.main
+elif app_name == 'error_server':
+    import error_server
+    func = error_server.main
 else:
-    raise AssertionError(app_name)
+    # Something broke with the earlier checks if the program got here.
+    sys.exit(f'Unable to set application behavior for "{app_name}"!')
 
 from trio_debug import Tracer
 tracer = Tracer() if utils.CODE_DEV_MODE else None


### PR DESCRIPTION
Reorganized and fixed some issues with how BEEMod's VBSP and VRAD determined what behaviors they should perform when called. Originally, it was explicit that the file name determined which behavior was used, but now it only checks the front half of the filename, so the latter half can be whatever it wants as long as it's separated by an underscore or period.

For example, `vbsp_bee.exe` will run VBSP when originally it would keep the `_bee` part and error. This is useful if you had something that you want to run first before BEEMod and calling it when the executable is named something else. The front half must still be either `vbsp` or `vrad` or it will still error as it will in fact error when it doesn't have that information.